### PR TITLE
only install the required databases based on the node configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,5 +2,5 @@ default["databox"]["db_root_password"] = nil
 
 # A list of database_user's attribute parameters.
 # See database cookbook for details.
-default["databox"]["databases"]["mysql"] = []
-default["databox"]["databases"]["postgresql"] = []
+default["databox"]["databases"]["mysql"] = nil
+default["databox"]["databases"]["postgresql"] = nil


### PR DESCRIPTION
the default sets

    default["databox"]["databases"]["mysql"] = []
    default["databox"]["databases"]["postgresql"] = []

but then the recipe checks

    if node["databox"]["databases"]["mysql"]
    if node["databox"]["databases"]["postgresql"]

those if statements seem to always evaluate to true because of the default