### PR TITLE
Fixes postgres database issue when using encoding: UTF8 on ubuntu 12.04

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default["databox"]["db_root_password"] = nil
+default["databox"]["postgresql"]["language"] = "en_US.UTF-8"
 
 # A list of database_user's attribute parameters.
 # See database cookbook for details.

--- a/recipes/postgresql.rb
+++ b/recipes/postgresql.rb
@@ -5,6 +5,10 @@
 # Install Postgresql and create specified databases and users.
 #
 
+# for postgres UTF-8
+Chef::Log.info "Set LANGUAGE environment variables to #{node["databox"]["postgresql"]["language"]}"
+ENV['LANGUAGE'] = ENV['LANG'] = ENV['LC_ALL'] = node["databox"]["postgresql"]["language"]
+
 root_password = node["databox"]["db_root_password"]
 if root_password
   Chef::Log.info %(Set node["postgresql"]["password"]["postgres"] attributes to node["databox"]["db_root_password"])


### PR DESCRIPTION
Sets the ENV['LANGUAGE'] to en_US.UTF-8 by default 

avoids error

```
FATAL: PG::Error: postgresql_database[DB_NAME] (databox::postgresql line
36) had an error:
PG::Error: ERROR:  encoding UTF8 does not match locale en_US
DETAIL:  The chosen LC_CTYPE setting requires encoding LATIN1.
```

on ubuntu 12.04 and below - might be worth adding since 12.04 is LTS - https://wiki.ubuntu.com/LTS 
