### PR TITLE
Only include database recipe if databases are defined

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,10 +4,10 @@
 #
 #
 
-if node["databox"]["databases"]["mysql"]
+if node["databox"]["databases"]["mysql"].any?
   include_recipe "databox::mysql"
 end
 
-if node["databox"]["databases"]["postgresql"]
+if node["databox"]["databases"]["postgresql"].any?
   include_recipe "databox::postgresql"
 end


### PR DESCRIPTION
Check on a empty array condition always return truthy results.

Evaluate if list of databases are empty instead.

This fixes #2
